### PR TITLE
self consistent hideDropDown in the event self.activeNavigationBarTitle is nil

### DIFF
--- a/Classes/APNavigationController.m
+++ b/Classes/APNavigationController.m
@@ -67,7 +67,9 @@
             weakSelf.isDropDownVisible = !weakSelf.isDropDownVisible;
             weakSelf.dropDownToolbar.hidden = YES;
         }];
-        self.navigationBar.topItem.title = self.originalNavigationBarTitle;
+        if (self.activeNavigationBarTitle) {
+			self.navigationBar.topItem.title = self.originalNavigationBarTitle;
+		}
         if(sender && [sender isKindOfClass:[UIBarButtonItem class]]){
             [(UIBarButtonItem *)sender setTitle:self.originalBarButtonTitle];
         }


### PR DESCRIPTION
currently if the user doesn't want the navigation bar to change they can set self.activeNavigationBarTitle to nil. however this was not previously symmetrically respected in hideDropDown resulting in an inconsistent state 
